### PR TITLE
Fix jogl native dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,7 @@
         
         <dependency>
             <groupId>org.jogamp.jogl</groupId>
-            <artifactId>jogl-all</artifactId>
+            <artifactId>jogl-all-main</artifactId>
             <version>2.3.2</version>
         </dependency>
         


### PR DESCRIPTION
As detailed in the following issue, the current dependencies don't contain the native jars.
https://github.com/processing/processing/issues/5350

There is an explanation about this at https://jogamp.org/wiki/index.php/Maven under Package details